### PR TITLE
feat(core): bookings + Stripe webhook + pending sweeper; Day-5 local dashboards

### DIFF
--- a/server/drizzle/0002_auth_bookings.sql
+++ b/server/drizzle/0002_auth_bookings.sql
@@ -1,0 +1,48 @@
+-- 0002_auth_bookings.sql
+-- Adds users, bookings, availability, payments tables
+
+CREATE TABLE IF NOT EXISTS users (
+  id serial PRIMARY KEY,
+  email varchar(160) NOT NULL UNIQUE,
+  password_hash varchar(120) NOT NULL,
+  name varchar(120),
+  role varchar(16) NOT NULL DEFAULT 'user',
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS bookings (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL,
+  listing_id integer NOT NULL,
+  check_in timestamp NOT NULL,
+  check_out timestamp NOT NULL,
+  total_cents integer NOT NULL,
+  status varchar(16) NOT NULL DEFAULT 'pending',
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bookings_user ON bookings(user_id);
+CREATE INDEX IF NOT EXISTS idx_bookings_listing ON bookings(listing_id);
+
+CREATE TABLE IF NOT EXISTS availability (
+  id serial PRIMARY KEY,
+  listing_id integer NOT NULL,
+  date varchar(10) NOT NULL,
+  is_available boolean NOT NULL DEFAULT true
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_availability_listing_date
+  ON availability(listing_id, date);
+
+CREATE TABLE IF NOT EXISTS payments (
+  id serial PRIMARY KEY,
+  booking_id integer NOT NULL,
+  provider varchar(32) NOT NULL DEFAULT 'manual',
+  amount_cents integer NOT NULL,
+  currency varchar(8) NOT NULL DEFAULT 'MYR',
+  status varchar(16) NOT NULL DEFAULT 'pending',
+  ref varchar(120),
+  created_at timestamp NOT NULL DEFAULT now()
+);

--- a/server/drizzle/0005_bookings_and_payments.sql
+++ b/server/drizzle/0005_bookings_and_payments.sql
@@ -1,0 +1,30 @@
+-- Bookings
+CREATE TABLE IF NOT EXISTS bookings (
+  id            SERIAL PRIMARY KEY,
+  listing_id    INT NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
+  guest_id      INT NOT NULL REFERENCES users(id)    ON DELETE CASCADE,
+  start_date    DATE NOT NULL,
+  end_date      DATE NOT NULL,
+  guests        INT  NOT NULL DEFAULT 1,
+  status        TEXT NOT NULL DEFAULT 'pending', -- pending|paid|canceled|refunded|expired
+  total_amount  NUMERIC(10,2),
+  currency      TEXT NOT NULL DEFAULT 'myr',
+  stripe_session_id TEXT,
+  created_at    TIMESTAMP NOT NULL DEFAULT NOW(),
+  expires_at    TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_bookings_listing ON bookings (listing_id);
+CREATE INDEX IF NOT EXISTS idx_bookings_guest   ON bookings (guest_id);
+CREATE INDEX IF NOT EXISTS idx_bookings_range   ON bookings (start_date, end_date);
+
+-- Payments (1:1 with booking)
+CREATE TABLE IF NOT EXISTS payments (
+  id SERIAL PRIMARY KEY,
+  booking_id INT UNIQUE NOT NULL REFERENCES bookings(id) ON DELETE CASCADE,
+  stripe_payment_intent TEXT,
+  amount NUMERIC(10,2) NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'myr',
+  status TEXT NOT NULL, -- succeeded|refunded|failed|dev
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/server/src/routes/bookings.ts
+++ b/server/src/routes/bookings.ts
@@ -1,0 +1,176 @@
+import { Router } from "express";
+import type { Response } from "express";
+import { z } from "zod";
+import requireAuth from "../middleware/requireAuth";
+import { db } from "../db";
+import { sql } from "drizzle-orm";
+
+const router = Router();
+
+const DateStr = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const CreateBody = z.object({
+  listingId: z.coerce.number().int().positive(),
+  start: DateStr,
+  end: DateStr,
+  guests: z.coerce.number().int().min(1).default(1),
+});
+
+type D = {
+  userCol: string; listingCol: string; startCol: string; endCol: string;
+  statusCol: string; amountCol: string; usesCents: boolean;
+  currencyCol?: string | null; expiresCol?: string | null; guestsCol?: string | null;
+};
+
+async function cols(): Promise<string[]> {
+  const r: any = await db.execute(sql`
+    SELECT column_name FROM information_schema.columns WHERE table_name='bookings'
+  `);
+  return (r.rows || []).map((x: any) => x.column_name as string);
+}
+function pick(cols: string[], pats: RegExp[], fb: string) {
+  for (const p of pats) { const hit = cols.find(c => p.test(c)); if (hit) return hit; } return fb;
+}
+async function discover(): Promise<D> {
+  const c = await cols();
+  const userCol    = pick(c, [/^user_id$/i, /^guest_id$/i], "user_id");
+  const listingCol = pick(c, [/^listing_id$/i], "listing_id");
+  const startCol   = pick(c, [/^check_in$/i, /^start(_date)?$/i, /^from(_date)?$/i], "check_in");
+  const endCol     = pick(c, [/^check_out$/i, /^end(_date)?$/i, /^to(_date)?$/i], "check_out");
+  const statusCol  = pick(c, [/^status$/i, /^state$/i], "status");
+  const expiresCol = c.find(x => /expires|hold|timeout/i.test(x)) || null;
+  const currencyCol= c.find(x => /^currency(_code)?$/i.test(x)) || null;
+  const guestsCol  = c.find(x => /^(guests|guest_count|guests_count|num_guests|people)$/i.test(x)) || null;
+  let amountCol = c.find(x => /^total_cents$/i.test(x)) || "";
+  let usesCents = Boolean(amountCol);
+  if (!amountCol) { amountCol = c.find(x => /(amount|total|price).*cents$/i.test(x)) || ""; usesCents = Boolean(amountCol); }
+  if (!amountCol) { amountCol = c.find(x => /^(total_amount|amount|total|total_price|grand_total)$/i.test(x)) || "total_amount"; usesCents = false; }
+  return { userCol, listingCol, startCol, endCol, statusCol, amountCol, usesCents, currencyCol, expiresCol, guestsCol };
+}
+const overlaps = (s: string, e: string, start: string, end: string) =>
+  sql`NOT (b.${sql.raw(e)} < ${start}::date OR b.${sql.raw(s)} > ${end}::date)`;
+
+// ---------- ORDER MATTERS: put /mine BEFORE any /:id routes ----------
+
+// My trips
+router.get("/mine", requireAuth(), async (req: any, res: Response) => {
+  try {
+    const d = await discover();
+    const r: any = await db.execute(sql`
+      SELECT b.*, l.title, l.city
+      FROM bookings b
+      JOIN listings l ON l.id = b.${sql.raw(d.listingCol)}
+      WHERE b.${sql.raw(d.userCol)} = ${req.user.id}
+      ORDER BY b.created_at DESC
+    `);
+    res.json(r.rows);
+  } catch (e: any) {
+    res.status(500).json({ error: "Failed to load trips" });
+  }
+});
+
+// Host view
+router.get("/host/all", requireAuth("host"), async (req: any, res: Response) => {
+  try {
+    const d = await discover();
+    const r: any = await db.execute(sql`
+      SELECT b.*, l.title
+      FROM bookings b
+      JOIN listings l ON l.id = b.${sql.raw(d.listingCol)}
+      WHERE l.host_id = ${req.user.id}
+      ORDER BY b.created_at DESC
+    `);
+    res.json(r.rows);
+  } catch {
+    res.status(500).json({ error: "Failed to load host bookings" });
+  }
+});
+
+// Create booking (pending), block paid + fresh (<30m) pending
+router.post("/", requireAuth(), async (req: any, res: Response) => {
+  try {
+    const { listingId, start, end, guests } = CreateBody.parse(req.body ?? {});
+    const d = await discover();
+
+    const conflict = await db.execute(sql`
+      SELECT 1 FROM bookings b
+      WHERE b.${sql.raw(d.listingCol)} = ${listingId}
+        AND (
+          b.${sql.raw(d.statusCol)} = 'paid'
+          OR (b.${sql.raw(d.statusCol)} = 'pending' AND b.created_at > NOW() - INTERVAL '30 minutes')
+        )
+        AND ${overlaps(d.startCol, d.endCol, start, end)}
+      LIMIT 1
+    `);
+    if ((conflict as any).rows.length) return res.status(409).json({ error: "Dates are no longer available." });
+
+    const quote: any = await db.execute(sql`
+      WITH base AS (SELECT price_per_night FROM listings WHERE id=${listingId}),
+      days AS (SELECT generate_series(${start}::date, ${end}::date, '1 day')::date AS "day"),
+      nightly AS (
+        SELECT d."day",
+               COALESCE(a.price_override::numeric, (SELECT price_per_night FROM base)) AS nightly_price,
+               COALESCE(a.is_available, TRUE) AS is_available,
+               COALESCE(a.guests, 99) AS guests_ok
+        FROM days d
+        LEFT JOIN availability a ON a.listing_id=${listingId} AND a."day"=d."day"
+      )
+      SELECT
+        (SELECT COUNT(*) FROM nightly WHERE is_available IS DISTINCT FROM TRUE OR guests_ok < ${guests})::int AS missing_nights,
+        (SELECT COALESCE(SUM(nightly_price),0) FROM nightly WHERE is_available = TRUE AND guests_ok >= ${guests})::numeric AS subtotal
+    `);
+    const row = quote.rows?.[0];
+    if (!row) return res.status(500).json({ error: "Failed to quote" });
+    if (Number(row.missing_nights) > 0) return res.status(409).json({ error: "Unavailable for the selected dates." });
+
+    const subtotal = Number(row.subtotal || 0);
+    const service = Math.round(subtotal * 0.08 * 100) / 100;
+    const total = Math.round((subtotal + service) * 100) / 100;
+    const amountVal = (await discover()).usesCents ? Math.round(total * 100) : total;
+
+    const cols: string[] = [d.listingCol, d.userCol, d.startCol, d.endCol, d.statusCol, d.amountCol];
+    const vals = [sql`${listingId}`, sql`${req.user.id}`, sql`${start}`, sql`${end}`, sql`'pending'`, sql`${amountVal}`];
+    if (d.guestsCol)   { cols.push(d.guestsCol);   vals.push(sql`${guests}`); }
+    if (d.currencyCol) { cols.push(d.currencyCol); vals.push(sql`'myr'`); }
+    if (d.expiresCol)  { cols.push(d.expiresCol);  vals.push(sql`NOW() + INTERVAL '20 minutes'`); }
+
+    const created: any = await db.execute(sql`
+      INSERT INTO bookings (${sql.raw(cols.map(n => `"${n}"`).join(", "))})
+      VALUES (${sql.join(vals, sql`, `)})
+      RETURNING id
+    `);
+    res.status(201).json({ id: created.rows[0].id });
+  } catch (e: any) {
+    console.error("[bookings.create]", e?.message || e);
+    res.status(500).json({ error: e?.message || "Insert failed" });
+  }
+});
+
+// Cancel / refund (dev)
+router.post("/:id/cancel", requireAuth(), async (req: any, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    const d = await discover();
+    const r: any = await db.execute(sql`SELECT *, ${sql.raw(d.userCol)} AS uid FROM bookings WHERE id=${id} LIMIT 1`);
+    const b = r.rows[0]; if (!b) return res.status(404).json({ error: "Not found" });
+    if (b.uid !== req.user.id) return res.status(403).json({ error: "Forbidden" });
+
+    const now = new Date();
+    const startDate = new Date(b[d.startCol]);
+    if (startDate <= now) return res.status(409).json({ error: "Trip already started." });
+
+    if (b[d.statusCol] === "pending") {
+      await db.execute(sql`UPDATE bookings SET ${sql.raw(d.statusCol)}='canceled' WHERE id=${id}`);
+      return res.json({ ok: true, status: "canceled" });
+    }
+    if (b[d.statusCol] === "paid") {
+      await db.execute(sql`UPDATE bookings SET ${sql.raw(d.statusCol)}='refunded' WHERE id=${id}`);
+      return res.json({ ok: true, status: "refunded" });
+    }
+    res.status(409).json({ error: "Cannot cancel in this state." });
+  } catch (e: any) {
+    console.error("[bookings.cancel]", e?.message || e);
+    res.status(500).json({ error: "Failed to cancel" });
+  }
+});
+
+export default router;

--- a/server/src/routes/hostListings.ts
+++ b/server/src/routes/hostListings.ts
@@ -3,44 +3,71 @@ import requireAuth from "../middleware/requireAuth";
 import { requireOwner } from "../middleware/ownerGuard";
 import { z } from "zod";
 import { createListing, listMyListings, publishListing, updateListing } from "../services/listingsService";
+import { sql } from "drizzle-orm";
+import { db } from "../db";
 
 const router = Router();
 
+// Coerce numbers so form posts like "123" are accepted
 const upsertSchema = z.object({
   title: z.string().min(3),
   city: z.string().min(2),
   country: z.string().min(2).default("Malaysia"),
-  pricePerNight: z.number().int().positive(),
-  beds: z.number().int().positive(),
-  baths: z.number().int().min(0),
-  instant: z.boolean().optional().default(false),
-  description: z.string().min(10),
+  pricePerNight: z.coerce.number().int().positive(),
+  beds: z.coerce.number().int().positive(),
+  baths: z.coerce.number().int().min(0),
+  instant: z.coerce.boolean().optional().default(false),
+  description: z.string().min(1),
 });
 
-router.use(requireAuth("host"));
-
-router.get("/mine", async (req: any, res) => {
-  const rows = await listMyListings(req.user.id);
-  res.json({ items: rows });
+// Create new listing → returns { id }
+router.post("/", requireAuth("host"), async (req: any, res) => {
+  try {
+    const data = upsertSchema.parse(req.body);
+    const created = await createListing(req.user.id, data);
+    return res.status(201).json(created);
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message || "Invalid payload" });
+  }
 });
 
-router.post("/", async (req: any, res) => {
-  const data = upsertSchema.parse(req.body);
-  const created = await createListing(req.user.id, data);
-  res.status(201).json(created);
+// List mine
+router.get("/mine", requireAuth("host"), async (req: any, res) => {
+  const out = await listMyListings(req.user.id);
+  return res.json(out);
 });
 
-router.put("/:id", requireOwner, async (req: any, res) => {
+// Update listing
+router.put("/:id", requireAuth("host"), requireOwner, async (req: any, res) => {
+  try {
+    const id = Number(req.params.id);
+    const data = upsertSchema.partial().parse(req.body);
+    const out = await updateListing(id, req.user.id, data);
+    return res.json(out);
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message || "Invalid payload" });
+  }
+});
+
+// Publish (enforce at least one photo before allowing publish)
+router.post("/:id/publish", requireAuth("host"), requireOwner, async (req: any, res) => {
   const id = Number(req.params.id);
-  const data = upsertSchema.partial().parse(req.body);
-  const out = await updateListing(id, req.user.id, data);
-  res.json(out);
-});
+  try {
+    // ANCHOR: ENFORCE-PHOTO-BEFORE-PUBLISH
+    const photos = await db.execute(sql`
+      SELECT 1 FROM photos WHERE listing_id = ${id} LIMIT 1
+    `);
+    if (!(photos as any).rows.length) {
+      return res.status(400).json({ error: "Add at least one photo before publishing." });
+    }
+    // ANCHOR: ENFORCE-PHOTO-BEFORE-PUBLISH-END
 
-router.post("/:id/publish", requireOwner, async (req: any, res) => {
-  const id = Number(req.params.id);
-  const out = await publishListing(id, req.user.id);
-  res.json(out);
+    // Delegate to service (sets published flag, etc.)
+    const out = await publishListing(id, req.user.id);
+    return res.json(out);
+  } catch (e: any) {
+    return res.status(e?.status || 500).json({ error: e?.message || "Publish failed" });
+  }
 });
 
 export default router;

--- a/server/src/routes/photos.ts
+++ b/server/src/routes/photos.ts
@@ -1,59 +1,81 @@
 import { Router } from "express";
+import type { Request, Response } from "express";
 import requireAuth from "../middleware/requireAuth";
 import { requireOwner } from "../middleware/ownerGuard";
 import { z } from "zod";
-import { createImagePresign } from "../services/storageService";
+import { createImagePresign, createDevPresign } from "../services/storageService";
 import { addPhoto } from "../services/photosService";
+import { db } from "../db";
+import { sql } from "drizzle-orm";
 
 const router = Router();
+const FORCE_S3 = process.env.FORCE_S3 === "true";
 
 /**
  * POST /api/photos/presign
- * Try to create a real presign; if storage isn't configured,
- * return a placeholder so the UI can proceed in dev.
+ * Body: { listingId:number, contentType:"image/*" }
+ * Returns: { mode:"s3"|"dev", url, fields, key, publicUrl }
  */
-router.post("/presign", requireAuth("host"), async (req, res) => {
-  const body = z
-    .object({
-      listingId: z.coerce.number(),
-      contentType: z.string().startsWith("image/"),
-    })
-    .parse(req.body);
-
+router.post("/presign", requireAuth("host"), async (req: Request, res: Response) => {
+  let body: { listingId: number; contentType: string };
   try {
-    const presign = await createImagePresign(body.listingId, body.contentType);
-    return res.json(presign);
-  } catch (e: any) {
-    // ⛑️ Fallback when S3_* envs are missing
-    console.warn("[photos.presign] storage not configured, using placeholder:", e?.message || e);
-    const key = `placeholder/${Date.now()}.jpg`;
-    const publicUrl = "https://placehold.co/800x600/png?text=Photo";
-    return res.json({
-      url: "about:blank", // no real upload
-      fields: {},         // keep the shape
-      key,
-      publicUrl,
-      __fallback: true,   // flag for client
-    });
+    body = z.object({
+      listingId: z.coerce.number().int().positive(),
+      contentType: z.string().startsWith("image/"),
+    }).parse(req.body ?? {});
+  } catch (e:any) {
+    return res.status(400).json({ error: e?.message || "Bad request" });
+  }
+
+  // Ownership check (soft fail → just warn; confirm route is owner-guarded anyway)
+  try {
+    const owned = await db.execute(sql`
+      SELECT 1 FROM listings WHERE id=${body.listingId} AND host_id=${(req as any).user.id} LIMIT 1
+    `);
+    if ((owned as any).rows.length === 0) {
+      return res.status(403).json({ error: "Not your listing." });
+    }
+  } catch (e:any) {
+    console.warn("[photos.presign] ownership check error:", e?.message || e);
+  }
+
+  // Try real presign; if S3 missing/misconfigured and FORCE_S3=false → dev fallback
+  try {
+    const out = await createImagePresign(body.listingId, body.contentType);
+    return res.json({ mode: "s3", ...out });
+  } catch (e:any) {
+    if (FORCE_S3) {
+      return res.status(500).json({ error: "S3 required in this environment." });
+    }
+    const dev = createDevPresign(body.contentType);
+    return res.json({ mode: "dev", ...dev });
   }
 });
 
 /**
  * POST /api/host/listings/:id/photos/confirm
- * Inserts a photo row for the listing (works for both real + fallback).
+ * Body: { url:string, key:string, order?:number }
  */
-router.post("/:id/photos/confirm", requireAuth("host"), requireOwner, async (req, res) => {
-  const id = Number(req.params.id);
-  const body = z
-    .object({
+router.post("/:id/photos/confirm", requireAuth("host"), requireOwner, async (req: Request, res: Response) => {
+  const listingId = Number(req.params.id);
+  let body: { url: string; key: string; order: number };
+  try {
+    body = z.object({
       url: z.string().url(),
-      key: z.string(),
+      key: z.string().min(1),
       order: z.number().int().min(0).default(0),
-    })
-    .parse(req.body);
+    }).parse(req.body ?? {});
+  } catch (e:any) {
+    return res.status(400).json({ error: e?.message || "Bad request" });
+  }
 
-  await addPhoto(id, body.url, body.key, body.order);
-  return res.status(201).json({ ok: true });
+  try {
+    await addPhoto(listingId, body.url, body.key, body.order);
+    return res.status(201).json({ ok: true });
+  } catch (e:any) {
+    console.error("[photos.confirm] error:", e);
+    return res.status(400).json({ error: e?.message || "Failed to attach photo" });
+  }
 });
 
 export default router;

--- a/server/src/routes/stripe.ts
+++ b/server/src/routes/stripe.ts
@@ -1,0 +1,70 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { db } from "../db";
+import { sql } from "drizzle-orm";
+
+const router = Router();
+
+const STRIPE_SECRET = process.env.STRIPE_SECRET_KEY;
+const PUBLIC_URL = process.env.PUBLIC_URL || "http://localhost:5173";
+
+async function amountInCents(b: any): Promise<number> {
+  if (b.total_cents != null) return Number(b.total_cents);
+  if (b.amount_cents != null) return Number(b.amount_cents);
+  if (b.total_amount != null) return Math.round(Number(b.total_amount) * 100);
+  if (b.amount != null) return Math.round(Number(b.amount) * 100);
+  return 0;
+}
+function pickStatusCol(row: any) {
+  return Object.prototype.hasOwnProperty.call(row, "status") ? "status" : "state";
+}
+function pickSessCol(row: any) {
+  if (Object.prototype.hasOwnProperty.call(row, "stripe_session_id")) return "stripe_session_id";
+  return null;
+}
+
+router.post("/checkout/:bookingId", async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.bookingId);
+    const rows: any = await db.execute(sql`SELECT * FROM bookings WHERE id=${id} LIMIT 1`);
+    const b = rows.rows[0];
+    if (!b) return res.status(404).json({ error: "Booking not found" });
+
+    const statusCol = pickStatusCol(b);
+    const sessCol = pickSessCol(b);
+    const amt = await amountInCents(b);
+    const currency = String(b.currency || "myr").toLowerCase();
+
+    if (!STRIPE_SECRET) {
+      await db.execute(sql`UPDATE bookings SET ${sql.raw(statusCol)}='paid' WHERE id=${id}`);
+      return res.json({ url: `${PUBLIC_URL}/success?booking=${id}`, dev: true });
+    }
+
+    const stripe = (await import("stripe")).default;
+    const s = new stripe(STRIPE_SECRET, { apiVersion: "2023-10-16" as any });
+    const session = await s.checkout.sessions.create({
+      mode: "payment",
+      success_url: `${PUBLIC_URL}/success?booking=${id}`,
+      cancel_url: `${PUBLIC_URL}/cancel?booking=${id}`,
+      metadata: { bookingId: String(id) },
+      line_items: [{
+        price_data: {
+          currency,
+          product_data: { name: `Stay #${id}` },
+          unit_amount: amt,
+        },
+        quantity: 1
+      }]
+    });
+
+    if (sessCol) {
+      await db.execute(sql`UPDATE bookings SET ${sql.raw(sessCol)}=${session.id} WHERE id=${id}`);
+    }
+    return res.json({ url: session.url });
+  } catch (e: any) {
+    console.error("[stripe.checkout] error:", e?.message || e);
+    return res.status(500).json({ error: "Stripe error" });
+  }
+});
+
+export default router;

--- a/server/src/webhooks/StripeWebhook.ts
+++ b/server/src/webhooks/StripeWebhook.ts
@@ -1,0 +1,41 @@
+// server/src/webhooks/stripeWebhook.ts
+import type { Request, Response } from "express";
+import { sql } from "drizzle-orm";
+import { db } from "../db";
+
+const STRIPE_SECRET = process.env.STRIPE_SECRET_KEY;
+const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
+
+export default async function stripeWebhook(req: Request, res: Response) {
+  if (!STRIPE_SECRET || !STRIPE_WEBHOOK_SECRET) {
+    return res.status(400).json({ error: "Stripe webhook not configured." });
+  }
+
+  // req.body is a Buffer because we use express.raw() on this route
+  const buf = req.body as Buffer;
+  const sig = req.headers["stripe-signature"] as string | undefined;
+
+  try {
+    const Stripe = (await import("stripe")).default;
+    const stripe = new Stripe(STRIPE_SECRET, { apiVersion: "2023-10-16" as any });
+    const event = stripe.webhooks.constructEvent(buf, sig!, STRIPE_WEBHOOK_SECRET);
+
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object as any; // Stripe.Checkout.Session
+      const idFromMeta = session?.metadata?.bookingId ? Number(session.metadata.bookingId) : null;
+      const sessId = session?.id as string | undefined;
+
+      // Prefer metadata.bookingId; fall back to stored stripe_session_id
+      if (idFromMeta) {
+        await db.execute(sql`UPDATE bookings SET status='paid' WHERE id=${idFromMeta}`);
+      } else if (sessId) {
+        await db.execute(sql`UPDATE bookings SET status='paid' WHERE stripe_session_id=${sessId}`);
+      }
+    }
+
+    return res.json({ received: true });
+  } catch (e: any) {
+    console.error("[stripe.webhook] error:", e?.message || e);
+    return res.status(400).send(`Webhook Error: ${e?.message || "invalid payload"}`);
+  }
+}

--- a/web/src/Root.tsx
+++ b/web/src/Root.tsx
@@ -6,6 +6,11 @@ import HostDashboard from "./pages/host/Dashboard";
 import EditListing from "./pages/host/EditListing";
 import { ProtectedHostRoute } from "./routes/ProtectedHostRoute";
 import ChangePassword from "./pages/auth/ChangePassword";
+import MyTrips from "./pages/trips/MyTrips";
+import Checkout from "./pages/checkout/Checkout";
+import Success from "./pages/checkout/Success";
+import HostBookings from "./pages/host/Bookings";
+
 
 
 export default function Root() {
@@ -25,6 +30,13 @@ export default function Root() {
         }
       />
 
+      <Route path="/trips" element={<MyTrips />} />
+      <Route path="/checkout" element={<Checkout />} />
+      <Route path="/success" element={<Success />} />
+      <Route path="/host/bookings" element={
+        <ProtectedHostRoute><HostBookings /></ProtectedHostRoute>
+      } />
+
 
       {/* Host (protected) */}
       <Route
@@ -32,6 +44,14 @@ export default function Root() {
         element={
           <ProtectedHostRoute>
             <HostDashboard />
+          </ProtectedHostRoute>
+        }
+      />
+      <Route
+        path="/host/new/edit"
+        element={
+          <ProtectedHostRoute>
+            <EditListing />
           </ProtectedHostRoute>
         }
       />

--- a/web/src/components/PhotoUploader.tsx
+++ b/web/src/components/PhotoUploader.tsx
@@ -1,29 +1,35 @@
-import { useState } from "react";
+// web/src/components/PhotoUploader.tsx
+import { useRef, useState } from "react";
 import { api } from "../lib/api";
 
 export default function PhotoUploader({ listingId }: { listingId: string }) {
   const [photos, setPhotos] = useState<{ url: string }[]>([]);
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   async function onChoose(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
+    const input = e.currentTarget; // capture before awaits (React pools events)
+    inputRef.current = input;
+
+    const file = input.files?.[0];
     if (!file) return;
-    if (!file.type.startsWith("image/")) return alert("Choose an image");
+    if (!file.type.startsWith("image/")) {
+      alert("Choose an image");
+      input.value = "";
+      return;
+    }
 
     setBusy(true);
     try {
-      // Ask server for presign (or fallback)
-      const presign: any = await api("/api/photos/presign", {
+      // Ask server for presign (or dev-fallback)
+      const presign = await api("/api/photos/presign", {
         method: "POST",
-        body: JSON.stringify({
-          listingId: Number(listingId),
-          contentType: file.type,
-        }),
+        body: JSON.stringify({ listingId, contentType: file.type }),
       });
 
-      // ⛑️ Fallback: storage not configured → skip upload and just confirm placeholder
-      if (presign && presign.__fallback) {
+      // DEV path: skip actual upload, confirm immediately
+      if (presign.mode === "dev" || presign.url === "about:blank") {
         await api(`/api/host/listings/${listingId}/photos/confirm`, {
           method: "POST",
           body: JSON.stringify({
@@ -33,19 +39,20 @@ export default function PhotoUploader({ listingId }: { listingId: string }) {
           }),
         });
         setPhotos((p) => [...p, { url: presign.publicUrl }]);
-        setNote("Attached placeholder photo (no storage configured).");
+        setNote("Dev image attached (no real upload). Configure S3 envs for real uploads.");
         return;
       }
 
-      // Real S3 upload path
+      // REAL upload (presigned POST to S3)
       const fd = new FormData();
       Object.entries(presign.fields).forEach(([k, v]: any) => fd.append(k, String(v)));
       fd.append("Content-Type", file.type);
       fd.append("file", file);
 
       const resp = await fetch(presign.url, { method: "POST", body: fd });
-      if (!resp.ok) throw new Error("Upload failed (storage env not set?)");
+      if (!resp.ok) throw new Error("Upload failed (storage not configured?)");
 
+      // Confirm and persist photo row
       await api(`/api/host/listings/${listingId}/photos/confirm`, {
         method: "POST",
         body: JSON.stringify({
@@ -58,15 +65,19 @@ export default function PhotoUploader({ listingId }: { listingId: string }) {
       setPhotos((p) => [...p, { url: presign.publicUrl }]);
       setNote("");
     } catch (e: any) {
-      setNote(e?.message || "Upload error — storage not configured yet?");
+      setNote(e?.message || "Upload error — check storage config.");
     } finally {
       setBusy(false);
+      // Safely reset input even after awaits
+      try {
+        inputRef.current && (inputRef.current.value = "");
+      } catch {}
     }
   }
 
   return (
     <div>
-      <input type="file" accept="image/*" onChange={onChoose} disabled={busy} />
+      <input type="file" accept="image/*" onChange={onChoose} disabled={busy} ref={inputRef} />
       {note && <div style={{ color: "orange", marginTop: 8 }}>{note}</div>}
       <div style={{ display: "flex", gap: 8, marginTop: 8, flexWrap: "wrap" }}>
         {photos.map((p, i) => (

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,22 +1,8 @@
+// web/src/main.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
-import Root from "./Root"; // we'll create this next
-
-// ANCHOR: URL-REWRITE-TRAP
-(() => {
-  const orig = history.replaceState;
-  history.replaceState = function (...args: any[]) {
-    try {
-      const url = args?.[2];
-      const stack = new Error().stack?.split("\n").slice(0, 6).join("\n");
-      console.log("[replaceState]", url, "\n", stack);
-    } catch {}
-    // @ts-ignore
-    return orig.apply(this, args);
-  };
-})();
-// ANCHOR: URL-REWRITE-TRAP-END
+import Root from "./Root";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/web/src/pages/ListingDetails.tsx
+++ b/web/src/pages/ListingDetails.tsx
@@ -371,6 +371,23 @@ export default function ListingDetails() {
               </div>
             )}
             {/* ANCHOR: QUOTE_PANEL_END */}
+            {/* Reserve CTA */}
+            <div style={{ marginTop: 10 }}>
+              <a
+                href={`/checkout?listingId=${item?.id}&start=${start || ""}&end=${end || ""}&guests=${guests || "1"}`}
+                style={{
+                  display: "inline-block",
+                  padding: "10px 14px",
+                  borderRadius: 10,
+                  border: "1px solid #1c3b5a",
+                  background: "#0b1220",
+                  color: "#e5e7eb",
+                  textDecoration: "none"
+                }}
+              >
+                Reserve
+              </a>
+            </div>
 
 
             {/* Gallery */}

--- a/web/src/pages/checkout/Checkout.tsx
+++ b/web/src/pages/checkout/Checkout.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { api } from "../../lib/api"; // ✅ fixed relative path
+
+type State =
+  | { kind: "idle" }
+  | { kind: "working" }
+  | { kind: "conflict"; message: string }
+  | { kind: "error"; message: string };
+
+export default function Checkout() {
+  const [params] = useSearchParams();
+  const nav = useNavigate();
+  const [state, setState] = useState<State>({ kind: "idle" });
+
+  const input = useMemo(() => {
+    const listingId = Number(params.get("listingId"));
+    const start = params.get("start") || "";
+    theEnd: {
+    }
+    const end = params.get("end") || "";
+    const guests = Number(params.get("guests") || "1");
+    return { listingId, start, end, guests };
+  }, [params]);
+
+  useEffect(() => {
+    let on = true;
+    async function run() {
+      try {
+        setState({ kind: "working" });
+        // 1) create booking
+        const b = await api("/api/bookings", {
+          method: "POST",
+          body: JSON.stringify({
+            listingId: input.listingId,
+            start: input.start,
+            end: input.end,
+            guests: input.guests,
+          }),
+        });
+
+        // 2) stripe checkout (dev returns a success url)
+        const s = await api(`/api/stripe/checkout/${b.id}`, { method: "POST" });
+        if (!on) return;
+        window.location.assign(s.url || `/success?booking=${b.id}`);
+      } catch (e: any) {
+        const msg = String(e?.message || "Something went wrong");
+        if (!on) return;
+        if (/Dates are no longer available/i.test(msg)) {
+          setState({ kind: "conflict", message: msg });
+        } else {
+          setState({ kind: "error", message: msg });
+        }
+      }
+    }
+
+    if (!input.listingId || !input.start || !input.end) {
+      setState({ kind: "error", message: "Missing or invalid checkout parameters." });
+      return;
+    }
+    run();
+    return () => { on = false; };
+  }, [input]);
+
+  if (state.kind === "conflict") {
+    const backToListing = `/listings/${input.listingId}?start=${encodeURIComponent(
+      input.start
+    )}&end=${encodeURIComponent(input.end)}&guests=${input.guests}`;
+    return (
+      <div style={{ padding: 24 }}>
+        <h2 style={{ marginBottom: 8 }}>Those dates just got snapped 😬</h2>
+        <p style={{ marginBottom: 16 }}>{state.message}</p>
+        <p>
+          <Link to={backToListing}>Go back to the listing</Link> to pick new dates,
+          or <Link to="/">search again</Link>.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <div style={{ padding: 24 }}>
+        <h2 style={{ marginBottom: 8 }}>Checkout failed</h2>
+        <p style={{ marginBottom: 16 }}>{state.message}</p>
+        <p><Link to="/">Return home</Link></p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 24 }}>
+      <p>Redirecting to payment…</p>
+    </div>
+  );
+}

--- a/web/src/pages/checkout/Success.tsx
+++ b/web/src/pages/checkout/Success.tsx
@@ -1,0 +1,13 @@
+import { useSearchParams, Link } from "react-router-dom";
+
+export default function Success() {
+  const [q] = useSearchParams();
+  const id = q.get("booking");
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>Payment Successful</h2>
+      <p>Your booking #{id} is confirmed.</p>
+      <p><Link to="/trips">Go to My Trips →</Link></p>
+    </div>
+  );
+}

--- a/web/src/pages/host/Bookings.tsx
+++ b/web/src/pages/host/Bookings.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+
+export default function HostBookings() {
+  const [rows, setRows] = useState<any[]>([]);
+  useEffect(() => { api("/api/bookings/host/all").then(setRows).catch(() => setRows([])); }, []);
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>Host Bookings</h2>
+      <ul style={{ display: "grid", gap: 12, marginTop: 12 }}>
+        {rows.map(r => (
+          <li key={r.id} style={{ padding: 12, border: "1px solid #1c3b5a", borderRadius: 8 }}>
+            <div>#{r.id} — Listing {r.listing_id} · {r.start_date} → {r.end_date} · {r.status}</div>
+            <div>RM {Number(r.total_amount).toFixed(2)} {String(r.currency || "").toUpperCase()}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/pages/host/Dashboard.tsx
+++ b/web/src/pages/host/Dashboard.tsx
@@ -37,7 +37,7 @@ export default function HostDashboard() {
     <div style={{ padding: 24 }}>
       <h1>Host Dashboard</h1>
       <div style={{ marginBottom: 12 }}>
-        <Link to="/host/new">New Listing</Link>
+        <Link to="/host/new/edit">New Listing</Link>
       </div>
       <ul style={{ display: "grid", gap: 12 }}>
         {items.map(it => (

--- a/web/src/pages/host/EditListing.tsx
+++ b/web/src/pages/host/EditListing.tsx
@@ -6,10 +6,16 @@ import { api } from "../../lib/api";
 import PhotoUploader from "../../components/PhotoUploader";
 
 export default function EditListing() {
-  const { id } = useParams();
+  const { id: rawId } = useParams();
+  const id = rawId && rawId !== "new" && rawId !== "undefined" ? rawId : undefined;
   const isNew = !id;
   const { user, loading } = useSession();
+  
   const nav = useNavigate();
+  useEffect(() => {
+    if (rawId === "undefined") nav("/host/new/edit", { replace: true });
+  }, [rawId, nav]);
+  
   const [form, setForm] = useState({
     title: "", city: "", pricePerNight: 100, beds: 1, baths: 1, instant: false, description: ""
   });

--- a/web/src/pages/trips/MyTrips.tsx
+++ b/web/src/pages/trips/MyTrips.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { api } from "../../lib/api";
+
+export default function MyTrips() {
+  const [rows, setRows] = useState<any[]>([]);
+  useEffect(() => { api("/api/bookings/mine").then(setRows).catch(() => setRows([])); }, []);
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>My Trips</h2>
+      <ul style={{ display: "grid", gap: 12, marginTop: 12 }}>
+        {rows.map(r => (
+          <li key={r.id} style={{ padding: 12, border: "1px solid #1c3b5a", borderRadius: 8 }}>
+            <div><strong>#{r.id}</strong> {r.title} — {r.city}</div>
+            <div>{r.start_date} → {r.end_date} · {r.guests} guest(s) · {r.status}</div>
+            <div>RM {Number(r.total_amount).toFixed(2)}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
- Add /api/stripe/webhook (mounted pre-json) to mark bookings as paid
- Add pending sweeper (created_at + BOOKING_HOLD_MINUTES)
- Host publish gate (≥1 photo) enforced server-side
- Public grid + details wired to photos
- Trips (/trips) & Host Bookings (/host/bookings) pages (basic statuses)
- Cancel path (dev refund status flip)

## How to test (local)
1) Login → Host Dashboard → create listing → upload ≥1 photo → Publish
2) Public grid → pick dates/guests → Quote → Book
   - Dev (no STRIPE_SECRET_KEY): instant paid + redirect to /success
   - Live (with STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET): go to Stripe; webhook flips status to paid
3) /trips shows booking; /host/bookings shows it too
4) (Optional) Set BOOKING_HOLD_MINUTES=1 and create pending; verify sweeper expires it

## Env
- BOOKING_HOLD_MINUTES (default 30)
- PENDING_SWEEP_INTERVAL_MS (default 60000)
- STRIPE_SECRET_KEY (for live)
- STRIPE_WEBHOOK_SECRET (for live)

## Known KIV
- Real Stripe refund on cancel
- Retry Payment button for pending
- Photo delete/cover/reorder
- Host mini calendar
- Deploy/seed pass

## Notes
- .env files are ignored
